### PR TITLE
Print both STDOUT and STDERR if they both exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6] - 2021-10-04
+### Fixed
+- STDERR gets printed even in the case when it is only emitted as a warning, narrenschiff now defaults to printing both STDOUT and STDERR if both exists
+
 ## [3.4.5] - 2021-09-13
 ### Fixed
 - Security issue `[B603:subprocess_without_shell_equals_true]` (Severity: Low)
@@ -26,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.4.1] - 2021-09-02
 ### Fixed
-- STDOUT gets printed event in the case of error, narrenschiff now defaults to printing STDOUT only if STDERR is missing from shell subprocess
+- STDOUT gets printed even in the case of error, narrenschiff now defaults to printing STDOUT only if STDERR is missing from shell subprocess
 - Test package is not a part of the distribution anymore
 
 ## [3.4.0] - 2021-08-21
@@ -216,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Cannot load keys and salts from paths that use `~`
 
+[3.4.6]: https://github.com/narrenorg/narrenschiff/compare/3.4.5...3.4.6
 [3.4.5]: https://github.com/narrenorg/narrenschiff/compare/3.4.4...3.4.5
 [3.4.4]: https://github.com/narrenorg/narrenschiff/compare/3.4.3...3.4.4
 [3.4.3]: https://github.com/narrenorg/narrenschiff/compare/3.4.2...3.4.3

--- a/narrenschiff/__init__.py
+++ b/narrenschiff/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "3.4.5"
+__version__ = "3.4.6"

--- a/narrenschiff/modules/common.py
+++ b/narrenschiff/modules/common.py
@@ -148,11 +148,17 @@ class NarrenschiffModule(ABC):
             stderr=subprocess.PIPE
         )
 
-        output = process.stderr if process.stderr else process.stdout
+        if process.stdout and process.stderr:
+            stdout = process.stdout.decode('utf-8')
+            stderr = process.stderr.decode('utf-8')
+            output = f'{stderr}\n{stdout}'
+        else:
+            output = process.stderr if process.stderr else process.stdout
+            output = output.decode('utf-8')
 
         logger.info(f'Command "{cmd}" executed')
 
-        return output.decode('utf-8'), process.returncode
+        return output, process.returncode
 
     def echo(self, output, rc):
         """


### PR DESCRIPTION
**Summary**
<!-- Please include a summary, any relevant motivation, context, and design decisions. -->
<!-- If you added new dependencies to the project, list them here. -->

<!-- If applicable, uncomment the following line, and replace (issue) with the actual issue number your change is fixing. -->
<!-- Fixes #(issue) -->

STDERR gets printed even in the case when it is only emitted as a warning, narrenschiff now defaults to printing both STDOUT and STDERR if both exists.

**Type of change**
<!-- Please mark relevant options: -->

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Unit test update
- [ ] CI/CD update

**Checklist**

- [ ] I have properly commented the new code
- [x] I have updated the documentation
- [x] The new code follows project style guidelines
- [x] The new code does not break existing unit tests
- [ ] I have added unit tests to cover the new code

**Additional context**
<!-- Add any other context about the pull request here. -->
N/A
